### PR TITLE
Record: Remove fsync for better performance

### DIFF
--- a/mqtt-record/main.go
+++ b/mqtt-record/main.go
@@ -79,7 +79,6 @@ var message_handler mqtt.MessageHandler = func(client mqtt.Client, msg mqtt.Mess
 
 	file.Write(buf_size)
 	file.Write(buf_payload)
-	file.Sync()
 }
 
 func main() {


### PR DESCRIPTION
When recording many messages, the recording callback is not fast enough and messages pile up in the TCP socket. (See #3)

TODO: Check, if this helps