### PR TITLE
Record: Print statistics on exit

### DIFF
--- a/mqtt-record/main.go
+++ b/mqtt-record/main.go
@@ -26,7 +26,7 @@ import (
 	msgpack "github.com/vmihailenco/msgpack/v5"
 )
 
-const buildVersion string = "v2.0.0"
+const buildVersion string = "v2.1.0"
 
 // global variables
 var file *os.File
@@ -38,6 +38,7 @@ var brokerURL string
 var topic string
 var filename string
 var statsOutput bool
+var versionMode bool
 
 const msgStatsTime int = 5 // report statistics every 5 seconds
 
@@ -83,6 +84,7 @@ func init() {
 	flag.StringVar(&topic, "t", "#", "MQTT topic to subscribe")
 	flag.StringVar(&filename, "o", "recording-$topic-$time.mqtt", "Output file name")
 	flag.BoolVar(&statsOutput, "s", false, "Print regular message statistics per topic")
+	flag.BoolVar(&versionMode, "version", false, "Print version number")
 	flag.Parse()
 }
 
@@ -152,6 +154,9 @@ func main() {
 	filename = strings.Replace(filename, "$time", filenameTimestamp, 1)
 
 	fmt.Println("MQTT Recorder " + buildVersion)
+	if versionMode {
+		os.Exit(0)
+	}
 	fmt.Println("- MQTT broker:     ", brokerURL)
 	fmt.Println("- Subscribe topic: ", topic)
 	fmt.Println("- Output filename: ", filename)

--- a/mqtt-replay/main.go
+++ b/mqtt-replay/main.go
@@ -27,7 +27,7 @@ import (
 	"golang.org/x/term"
 )
 
-const buildVersion string = "v2.0.0"
+const buildVersion string = "v2.1.0"
 
 // configuration values
 const skipSeconds int = 5
@@ -37,6 +37,7 @@ var brokerURL string
 var filename string
 var startTimeSec uint
 var endTimeSec uint // end time of 0 seconds doesn't make sense, so use it for "full file"
+var versionMode bool
 
 // internal state
 var shouldHalt bool
@@ -49,9 +50,10 @@ func init() {
 	flag.StringVar(&filename, "i", "", "Input file (REQUIRED)")
 	flag.UintVar(&startTimeSec, "s", 0, "Starting time offset (seconds)")
 	flag.UintVar(&endTimeSec, "e", 0, "End time (seconds, leave out for full file)")
+	flag.BoolVar(&versionMode, "version", false, "Print version number")
 	flag.Parse()
 
-	if filename == "" {
+	if filename == "" && !versionMode {
 		println("ERROR: Input file name not set!")
 		println("Usage:")
 		flag.PrintDefaults()
@@ -263,7 +265,10 @@ func readKeypress() (string, error) {
 }
 
 func main() {
-	fmt.Println("MQTT Recording Replay " + buildVersion)
+	fmt.Println("MQTT Recording Player " + buildVersion)
+	if versionMode {
+		os.Exit(0)
+	}
 	fmt.Println("- MQTT broker:     ", brokerURL)
 	fmt.Println("- Input filename:  ", filename)
 	if endTimeSec > 0 {


### PR DESCRIPTION
Print a list of recevied topics with average message rate and size.

Output looks like this:
```
Message Statistics by Topic:
hmi/tx/ble/glosa/spat    :   808 msg,     56/    56/    56 byte,  135/ 254/ 373 ms delta (min/avg/max)
hmi/tx/ble/own_pos       :   808 msg,     83/    83/    83 byte,  136/ 254/ 373 ms delta (min/avg/max)
hmi/tx/json/cam          :  1063 msg,    225/   252/   272 byte,    0/ 193/ 551 ms delta (min/avg/max)
hmi/tx/proto/glosa       :   808 msg,     54/    54/    54 byte,  135/ 254/ 373 ms delta (min/avg/max)
hmi/tx/proto/simplecam   :  1063 msg,     84/   153/   224 byte,    0/ 193/ 551 ms delta (min/avg/max)
v2x/rx/cam               :  1063 msg,    167/   246/   327 byte,    0/ 193/ 583 ms delta (min/avg/max)
v2x/rx/obu_gnss          :   808 msg,   3481/  3662/  3764 byte,  132/ 254/ 385 ms delta (min/avg/max)
```